### PR TITLE
Add Scholars / PhD programs @ National University of Singapore

### DIFF
--- a/programs_en.md
+++ b/programs_en.md
@@ -1,4 +1,4 @@
-# Master programs 
+# Master programs
 
 ## China, Mainland
 
@@ -26,9 +26,7 @@
 
    **[University of British Columbia, Phd in Sociology](https://sociology.ubc.ca/graduate/phd-program/)** ([Clayton Childress](https://claytonchildress.weebly.com), [Laura Nelson](https://www.lauraknelson.com/))
 
-
 ## China, Mainland
-
 
    **[Beijing Normal University, PhD in System Science](https://sss.bnu.edu.cn/rcpy/xsbs/zsjz2/index.htm)** ([Jiang Zhang/张江](https://jake.swarma.org/index.html), [An Zeng/曾安](https://sss.bnu.edu.cn/szdw/zzjs/js/8b4c96518e694080a5319f428abe045f.htm))
 
@@ -68,8 +66,6 @@
 
   **[University of Hong Kong, PhD in Politics and Public Administration](https://ppa.hku.hk/programmes/rpg/mphil-phd)** ([Haohan Chen](https://haohanchen.github.io/))
 
-
-
 ## European Continent
 
   **[Institut Europeen d'Administration des Affaires, PhD in Management](https://www.insead.edu/phd/admissions-and-financing)** ([Frédéric Godart](https://www.insead.edu/faculty-personal-site/frederic-godart))
@@ -77,6 +73,10 @@
   **[Max Planck Institute, PhD in Computer and Information Science](https://www.cis.mpg.de/csmaxplanck-overview/)** ([Iyad Rahwan](https://www.rahwan.me/))
   
   **[University of Zurich, PhD in Communication and Media Research](https://www.ikmz.uzh.ch/en/studies/doctorate.html)** ([Jing Zeng](https://www.ikmz.uzh.ch/en/research/divisions/computational-social-and-communication-science/team/jing-zeng.html))
+
+## Singapore
+
+   **[National University of Singapore](https://fass.nus.edu.sg/cnm/phd/)** ( [Kokil Jaidka](https://discovery.nus.edu.sg/17291-kokil-jaidka), [Renwen Zhang/张人文](https://discovery.nus.edu.sg/20836-renwen-zhang), [Subhayan Mukerjee](https://discovery.nus.edu.sg/19113-subhayan-mukerjee), [Weiyu Zhang/张玮玉](https://discovery.nus.edu.sg/1768-weiyu-zhang/about); *alphabetical*)
 
 ## United Kingdom
 
@@ -87,10 +87,11 @@
    **[University of Warwick, PhD in Interdisciplinary Studies](https://warwick.ac.uk/fac/cross_fac/cim/apply-to-study/phd-programmes/)** ([Ching Jin](https://warwick.ac.uk/fac/cross_fac/cim/people/ching-jin/))
 
 ## United States of America
+
    **[Brown University, PhD in Sociology](https://www.brown.edu/academics/sociology/programs/phd)** ([Jennifer Candipan](https://vivo.brown.edu/display/jcandipa), [Han Zhang](https://hanzhang.xyz/))
 
    **[Carnegie Mellon University University, PhD in Human Computer Interaction](https://hcii.cmu.edu/academics/phd-hci)** ([Hirokazu Shirado](https://www.shirado.net/), [Haiyi Zhu](https://haiyizhu.com/), [Geoff Kaufman](https://www.hcii.cmu.edu/people/geoff-kaufman), [Aniket Kittur](https://kittur.org/))
-   
+
    **[Carnegie Mellon University University, PhD in Social and Decision Science](https://www.cmu.edu/dietrich/sds/graduate/index.html)** ([Simon DeDeo](https://sites.santafe.edu/~simon/))
 
    **[Carnegie Mellon University University, PhD in Societal Computing](https://sc.cs.cmu.edu/)** ([Kathleen Carley](http://www.casos.cs.cmu.edu/bios/carley/carley.html), [Patrick Park](https://patpark.org/))
@@ -111,7 +112,7 @@
 
    **[Georgia Institute of Technology, PhD in Human-Centered Computing](https://www.cc.gatech.edu/degree-programs/phd-human-centered-computing)** ([Munmun De Choudhury](http://www.munmund.net/), [Clio Andris](https://planning.gatech.edu/people/clio-andris))
 
-   **[George Mason University, PhD in Computational Social Science](https://science.gmu.edu/academics/departments-units/computational-data-sciences/computational-social-science-phd)** 
+   **[George Mason University, PhD in Computational Social Science](https://science.gmu.edu/academics/departments-units/computational-data-sciences/computational-social-science-phd)**
 
    **[Harvard University, PhD in Government](https://gsas.harvard.edu/program/government)** ([Kosuke Imai](https://imai.fas.harvard.edu), [Gary King](https://gking.harvard.edu))
 
@@ -120,7 +121,7 @@
    **[Indiana University Bloomington, Ph.D. in Informatics](https://informatics.indiana.edu/programs/phd-informatics/index.html)** ([YY Ahn](http://yongyeol.com/))
 
    **[Massachusetts Institute of Technology, PhD in Media Arts & Sciences (apply through master program)](https://www.media.mit.edu/graduate-program/about-media-arts-sciences/)** ([Alex Pentland](https://www.media.mit.edu/people/sandy/overview/), [Deb Roy](https://www.media.mit.edu/people/dkroy/overview/))
-   
+
    **[Massachusetts Institute of Technology, PhD in Sloan](https://mitsloan.mit.edu/phd#tour-welcome)** ([Sinan Aral](https://www.sinanaral.io/), [Dean Eckles](https://www.deaneckles.com/), [David Rand](https://davidrand-cooperation.com/), [Abdullah Almaatouq](http://amaatouq.io/))
 
    **[Massachusetts Institute of Technology, PhD in Social & Engineering Systems](https://idss.mit.edu/academics/ses_doc/)** ([Alex Pentland](https://www.media.mit.edu/people/sandy/overview/))
@@ -130,7 +131,7 @@
    **[Northeastern University, PhD in Network Science](https://www.networkscienceinstitute.org/phd)** ([Barabási](https://www.barabasilab.com/), [David Lazer](https://www.lazerlab.net/people/david-lazer))
 
    **[Northwestern University, PhD in Management & Organizations](https://www.kellogg.northwestern.edu/doctoral/programs/management-and-organizations.aspx)** (The [NICO](https://www.nico.northwestern.edu/) group)
-   
+
    **[Northwestern University, PhD in Media, Technology, and Society](https://mts.northwestern.edu/program-of-study/)** ([Emőke-Ágnes Horvát](https://agneshorvat.soc.northwestern.edu/), [Noshir Contractor](https://nosh.northwestern.edu/), [Yingdan Lu](https://yingdanlu.com/), [Aaron Shaw](https://communication.northwestern.edu/faculty/aaron-shaw.html))
 
    **[Northwestern University, PhD in Sociology](https://sociology.northwestern.edu/graduate/)** ([Andrew Papachristos](https://sociology.northwestern.edu/people/faculty/core/andrew-v.--papachristos-.html), [Doron Shiffer-Sebba](https://doronshiffersebba.com/), [Oscar Stuhler](https://oscarstuhler.org/))
@@ -160,7 +161,7 @@
    **[Stanford University, PhD in Communications](https://comm.stanford.edu/phd)** ([Jennifer Pan](https://jenpan.com))
 
    **[Stanford University, PhD in Management Science and Engineering](https://msande.stanford.edu/academics-admissions/graduate/phd-program/phd-degree#computational)** ([Johan Ugander](http://stanford.edu/~jugander/), [Walter Powell](https://woodypowell.com/), [Amir Goldberg](https://www.gsb.stanford.edu/faculty-research/faculty/amir-goldberg))
-   
+
    **[Stanford University, PhD at Graduate School of Business](https://www.gsb.stanford#.edu/programs/phd)** ([Walter Powell](https://woodypowell.com/), [Amir Goldberg](https://www.gsb.stanford.edu/faculty-research/faculty/amir-goldberg), [Douglas Guilbeault](https://www.gsb.stanford.edu/faculty-research/faculty/douglas-r-guilbeault))
 
    **[Stanford University, PhD in Political Science](https://politicalscience.stanford.edu/graduate-program/phd-admissions)** ([Justin Grimmer](https://politicalscience.stanford.edu/people/justin-ryan-grimmer), [Jennifer Pan](https://jenpan.com), [Yiqing Xu](https://yiqingxu.org/))
@@ -186,14 +187,14 @@
    **[University of Chicago, PhD in Political Science](https://political-science.uchicago.edu/graduate-study)** ([Molly Offer-Westort](https://mollyow.github.io), [Anton Strezhnev](https://www.antonstrezhnev.com), [Rochelle Terman](https://rochelleterman.com))
 
    **[University of Chicago, Harris School of Public Policy, PhD in Public Policy](https://harris.uchicago.edu/academics/degrees/phd)** ([Christopher Berry](https://miurban.uchicago.edu/bio_christopher-berry/))
-   
+
    **[University of Chicago, PhD in Sociology](https://sociology.uchicago.edu/graduate-study)** ([James Evans](https://sociology.uchicago.edu/directory/James-A-Evans), [Bernard Koch](https://bernardjkoch.com/), [John Levi Martin](https://sociology.uchicago.edu/directory/John-Levi-Martin))
 
    **[University of Georgia, PhD in Sociology](https://grad.uga.edu/degree/phd-sociology/)** ([Peng Huang](https://penghuang.me/), [Yilang Peng](https://yilangpeng.com/))
 
-   **[University of Illinois Urbana-Champaign, PhD in Informatics](https://informatics.ischool.illinois.edu/phd-admission/)** 
+   **[University of Illinois Urbana-Champaign, PhD in Informatics](https://informatics.ischool.illinois.edu/phd-admission/)**
 
-   **[University of Illinois Urbana-Champaign, PhD in Information Sciences](https://ischool.illinois.edu/degrees-programs/graduate/phd-information-sciences)** 
+   **[University of Illinois Urbana-Champaign, PhD in Information Sciences](https://ischool.illinois.edu/degrees-programs/graduate/phd-information-sciences)**
 
    **[University of Iowa, PhD in Sociology](https://sociology.uiowa.edu/graduate/sociology-phd)** ([Yongren Shi](https://sociology.uiowa.edu/people/yongren-shi))
 

--- a/researcher_en.md
+++ b/researcher_en.md
@@ -4,29 +4,27 @@ One researcher can work on multiple topics/sub-topics. There is no formal defini
 
 ## Content Structure
 
-
- - AI and Society
-   - AI Algorithom and Social Impact
-   - AI for Social Networks
-   - Human-AI System/Interaction/Augmentation
-   - Natural Langugage Processing
-   - Others
- - City/Urban/Geo-Analysis
- - Complex System/Networks
- - Cultural
- - Economy
- - Gender/Race
- - Law
- - Management
+- AI and Society
+  - AI Algorithom and Social Impact
+  - AI for Social Networks
+  - Human-AI System/Interaction/Augmentation
+  - Natural Langugage Processing
+  - Others
+- City/Urban/Geo-Analysis
+- Complex System/Networks
+- Cultural
+- Economy
+- Gender/Race
+- Law
+- Management
    -Collective Intelligence
- - Politics and Policy
- - Psychology/Cognitive Science
- - Science of Science
- - Social Movement
- - Social Media/Communication
-   - Misinformation/Information Diffusion
-   - (Online) Community and Behavior
-
+- Politics and Policy
+- Psychology/Cognitive Science
+- Science of Science
+- Social Movement
+- Social Media/Communication
+  - Misinformation/Information Diffusion
+  - (Online) Community and Behavior
 
 # AI and Society
 
@@ -60,7 +58,6 @@ One researcher can work on multiple topics/sub-topics. There is no formal defini
 
 **[Yang Yang/杨洋](http://yangy.org/)** (Zhejiang University, Mainland China)
 
-
 ## Natural Langugage Processing (with focus on computational social science)
 
 **[Cristian Danescu-Niculescu-Mizil](https://www.cs.cornell.edu/~cristian/)** (Cornell University, USA)
@@ -88,6 +85,8 @@ One researcher can work on multiple topics/sub-topics. There is no formal defini
 **[Justine Zhang](https://tisjune.github.io/)** (University of Michigan, USA)
 
 **[Ken Benoit](https://kenbenoit.net/)** (Singapore Management University, Singapore)
+
+**[Kokil Jaidka](https://discovery.nus.edu.sg/17291-kokil-jaidka/)** (National University of Singapore, Singapore)
 
 **[Paramveer Dhillon](https://pdhillon.com/)** (University of Michigan, USA)
 
@@ -125,6 +124,8 @@ One researcher can work on multiple topics/sub-topics. There is no formal defini
 
 **[Paul Resnick](https://presnick.people.si.umich.edu/)** (University of Michigan, USA)
 
+**[Renwen Zhang](https://discovery.nus.edu.sg/20836-renwen-zhang)** (National University of Singapore, Singapore)
+
 **[Taha Yasseri](https://tahayasseri.com/)** (Trinity College Dublin, Ireland)
 
 **[Yang Wang](http://yangwang.ischool.illinois.edu/)** (University of Illinois Urbana-Champaign, USA)
@@ -143,9 +144,7 @@ One researcher can work on multiple topics/sub-topics. There is no formal defini
 
 **[Xinyue Ye](https://www.arch.tamu.edu/staff/xinyue-ye/)** (Texas A&M University, USA)
 
-
 # Complex System/Networks
-
 
 **[Aaron Clauset](https://www.colorado.edu/faculty/clauset/)** (University of Colorado Boulder, USA)
 
@@ -291,7 +290,6 @@ One researcher can work on multiple topics/sub-topics. There is no formal defini
 
 **[Yingdan Lu](https://yingdanlu.com/)** (Northwestern University, USA)
 
-
 # Psychology/Cognitive Science
 
 **[Brandon Batzloff](https://ischool.illinois.edu/people/brandon-batzloff)** (University of Illinois Urbana-Champaign, USA)
@@ -380,7 +378,9 @@ One researcher can work on multiple topics/sub-topics. There is no formal defini
 
 # Social Media/Communication
 
+**[Subhayan Mukerjee](https://discovery.nus.edu.sg/19113-subhayan-mukerjee)** (National University of Singapore, Singapore)
 
+**[Weiyu Zhang/张玮玉](https://discovery.nus.edu.sg/1768-weiyu-zhang)** (National University of Singapore, Singapore)
 
 ## Misinformation/Information Diffusion
 
@@ -428,7 +428,6 @@ One researcher can work on multiple topics/sub-topics. There is no formal defini
 
 **[Yingdan Lu](https://yingdanlu.com/)** (Northwestern University, USA)
 
-
 ## (Online) Community and Behavior
 
 **[Bogdan Vasilescu](https://bvasiles.github.io/)** (Carnegie Mellon University, USA)
@@ -450,5 +449,3 @@ One researcher can work on multiple topics/sub-topics. There is no formal defini
 **[Suzy Moat](https://www.wbs.ac.uk/about/person/suzy-moat/)** (Warwick Business School, UK)
 
 **[Yun Huang](https://yunhuang.web.illinois.edu/)** (University of Illinois Urbana-Champaign, USA)
-
-


### PR DESCRIPTION
In this PR, I provide information about:

- NUS CNM PhD program, having more than four scholars in computational communication
- NUS CSS Scholars in Communication, specialized in NLP, HCI, and Social Media Platforms.